### PR TITLE
Fix accidental JUnit 4 usages

### DIFF
--- a/qtakes/src/test/java/com/canehealth/ckblib/qtakes/service/QtakesServiceTest.java
+++ b/qtakes/src/test/java/com/canehealth/ckblib/qtakes/service/QtakesServiceTest.java
@@ -3,8 +3,8 @@ package com.canehealth.ckblib.qtakes.service;
 import java.util.concurrent.TimeUnit;
 
 import com.canehealth.ckblib.qtakes.model.QtakesRoot;
-import org.junit.After;
-import org.junit.BeforeClass;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.mockserver.client.server.MockServerClient;
 import org.mockserver.integration.ClientAndServer;
@@ -30,12 +30,12 @@ public class QtakesServiceTest {
 
     private static ClientAndServer mockServer;
 
-    @BeforeClass
+    @BeforeAll
     public static void startServer() {
         mockServer = startClientAndServer(1080);
     }
 
-    @After
+    @AfterAll
     public static void stopServer() {
         mockServer.stop();
     }

--- a/umls/src/test/java/com/canehealth/ckblib/umls/service/RestTicketServiceTest.java
+++ b/umls/src/test/java/com/canehealth/ckblib/umls/service/RestTicketServiceTest.java
@@ -1,7 +1,7 @@
 package com.canehealth.ckblib.umls.service;
 
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import com.canehealth.ckblib.umls.model.SearchRoot;
 import com.canehealth.ckblib.umls.model.SingletonRoot;
 import org.junit.jupiter.api.Test;


### PR DESCRIPTION
This project uses JUnit Jupiter (`org.junit.jupiter:junit-jupiter`), but implicitly has a transitive dependency on JUnit 4 (`junit:junit`) via the mockserver dependency (`org.mock-server:mockserver-core`), which allowed some accidental usages of JUnit 4's classes even though they shouldn't be used.

This PR fixes those accidental usages and aligns them to use their corresponding JUnit Jupiter counterparts.

In addition, it fixes a subtle bug in `QtakesServiceTest` - the mock server is started once for the entire test class (with the `@BeforeClass` annotation), but stopped after every test (with the `@After` annotation). This goes unnoticed since the class contains only one test, but it is still wrong, and will prevent adding more tests to this class in the future. Replacing those annotations with JUnit Jupiter's `@BeforeAll` and `@AfterAll` respectively solves this issue.